### PR TITLE
Translate coordinates correctly if suggestion view is not in its target's immediate superview

### DIFF
--- a/SHEmailValidator/SHAutocorrectSuggestionView.m
+++ b/SHEmailValidator/SHAutocorrectSuggestionView.m
@@ -88,7 +88,7 @@ static const NSInteger kDismissButtonWidth = 30;
         CGFloat left = MAX(10, target.center.x - width / 2);
         CGFloat top = target.frame.origin.y - height + 4;
 
-        self.frame = CGRectMake(left, top, width, height);
+        self.frame = CGRectIntegral(CGRectMake(left, top, width, height));
         self.opaque = NO;
         
         self.titleRect = CGRectMake((width - kDismissButtonWidth - titleSize.width) / 2, kCornerRadius, titleSize.width, titleSize.height);
@@ -192,7 +192,9 @@ static const NSInteger kDismissButtonWidth = 30;
     
     self.alpha = 0.2;
     self.transform = CGAffineTransformMakeScale(0.6, 0.6);
-    
+
+    // Frame is in target.superview coordinates
+    self.frame = [target.superview convertRect:self.frame toView:container];
     [container addSubview:self];
     
     [UIView animateWithDuration:0.2
@@ -215,7 +217,7 @@ static const NSInteger kDismissButtonWidth = 30;
     CGFloat left = MAX(10, self.target.center.x - width / 2);
     CGFloat top = self.target.frame.origin.y - height;
     
-    self.frame = CGRectMake(left, top, width, height);
+    self.frame = CGRectIntegral([self.target.superview convertRect:CGRectMake(left, top, width, height) toView:self.superview]);
 }
 
 - (void)dismiss


### PR DESCRIPTION
This works around issues I was seeing when trying to show a suggestion popup for a UITextField in a table view cell. The popup would display behind the above cell in the table view. This change allows using the tableview itself as the container view. The existing examples appear to still work fine.

Also threw in some CGRectIntegral's to fix periodic anti-aliasing (fuzziness) if `target.center.x - width / 2` came out to a non-integral number.
