### PR TITLE
Delete pull_request_template, default to the community health template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-**Issue Link**
-<!-- Link to the Jira ticket or GitHub issue -->
-
-**Description**
-<!-- Describe what items this PR changes. -->


### PR DESCRIPTION
**Description**
Deleting the pull_request_template.md file so we can rely on the new community health repo:

https://github.com/spothero/.github
