### PR TITLE
Added boilerplate for SHAutocorrectSuggestionView

### DIFF
--- a/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
+++ b/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  AutocorrectSuggestionViewDelegate.swift
+//  SpotHeroEmailValidator
+//
+//  Created by Brian Drelling on 5/7/20.
+//  Copyright © 2020 SpotHero, Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol AutocorrectSuggestionViewDelegate: AnyObject {
+    func suggestionView(_ suggestionView: SHAutocorrectSuggestionView, wasDismissedWithAccepted accepted: Bool)
+}

--- a/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
+++ b/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// Work In Progress -- This is a boilerplate file for Swift conversion. It is not included in the target.
 protocol AutocorrectSuggestionViewDelegate: AnyObject {
     func suggestionView(_ suggestionView: SHAutocorrectSuggestionView, wasDismissedWithAccepted accepted: Bool)
 }

--- a/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
+++ b/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
@@ -1,0 +1,40 @@
+//
+//  SHAutocorrectSuggestionView.swift
+//  SpotHeroEmailValidator
+//
+//  Created by Brian Drelling on 5/7/20.
+//  Copyright © 2020 SpotHero, Inc. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public typealias SetupBlock = (SHAutocorrectSuggestionView?) -> Void
+
+public class SHAutocorrectSuggestionView {
+    weak var delegate: AutocorrectSuggestionViewDelegate?
+
+    public var suggestedText: String?
+    public var fillColor: UIColor?
+    public var titleColor: UIColor?
+    public var suggestionColor: UIColor?
+
+    public static func defaultFillColor() -> UIColor { return .black }
+    public static func defaultTitleColor() -> UIColor { return .white }
+    public static func defaultSuggestionColor() -> UIColor { return UIColor(red: 0.5, green: 0.5, blue: 1.0, alpha: 1.0) }
+    
+    public static func show(from target: UIView,
+                            title: String?,
+                            autocorrectSuggestion suggestion: String?,
+                            withSetupBlock block: SetupBlock) -> SHAutocorrectSuggestionView { return SHAutocorrectSuggestionView() }
+
+    public static func show(from target: UIView,
+                            inContainerView container: UIView,
+                            title: String?,
+                            autocorrectSuggestion suggestion: String?,
+                            withSetupBlock block: SetupBlock) -> SHAutocorrectSuggestionView { return SHAutocorrectSuggestionView() }
+
+    public func updatePosition() { }
+
+    public func dismiss() { }
+}

--- a/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
+++ b/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
@@ -11,6 +11,7 @@ import UIKit
 
 public typealias SetupBlock = (SHAutocorrectSuggestionView?) -> Void
 
+// Work In Progress -- This is a boilerplate file for Swift conversion. It is not included in the target.
 public class SHAutocorrectSuggestionView {
     weak var delegate: AutocorrectSuggestionViewDelegate?
 

--- a/Sources/SpotHeroEmailValidator/SHEmailValidationTextField.swift
+++ b/Sources/SpotHeroEmailValidator/SHEmailValidationTextField.swift
@@ -144,7 +144,7 @@ public class SHEmailValidationTextField: UITextField {
 }
 
 extension SHEmailValidationTextField: AutocorrectSuggestionViewDelegate {
-    public func suggestionView(_ suggestionView: SHAutocorrectSuggestionView!, wasDismissedWithAccepted accepted: Bool) {
+    public func suggestionView(_ suggestionView: SHAutocorrectSuggestionView, wasDismissedWithAccepted accepted: Bool) {
         if accepted {
             self.text = suggestionView.suggestedText
         }

--- a/SpotHeroEmailValidator.xcodeproj/project.pbxproj
+++ b/SpotHeroEmailValidator.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		34121DC92355121E005393F2 /* SpotHeroEmailValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotHeroEmailValidatorTests.swift; sourceTree = "<group>"; };
 		3422112B24647AFF0002E7C6 /* EmailTextFieldDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailTextFieldDelegate.swift; sourceTree = "<group>"; };
 		342211372464AED90002E7C6 /* SHEmailValidationTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHEmailValidationTextField.swift; sourceTree = "<group>"; };
+		342211392464BAA80002E7C6 /* SHAutocorrectSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHAutocorrectSuggestionView.swift; sourceTree = "<group>"; };
+		3422113B2464BB390002E7C6 /* AutocorrectSuggestionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocorrectSuggestionViewDelegate.swift; sourceTree = "<group>"; };
 		342A1B162352A7EA00070FCD /* String+LevenshteinDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+LevenshteinDistance.swift"; sourceTree = "<group>"; };
 		342A1B192352AE1B00070FCD /* SHValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHValidationResult.swift; sourceTree = "<group>"; };
 		342A1B1E2352BE4F00070FCD /* NSString+LevenshteinDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+LevenshteinDistance.swift"; sourceTree = "<group>"; };
@@ -89,10 +91,12 @@
 		34497700234C289600D71628 /* SpotHeroEmailValidator */ = {
 			isa = PBXGroup;
 			children = (
-				342211372464AED90002E7C6 /* SHEmailValidationTextField.swift */,
-				3422112B24647AFF0002E7C6 /* EmailTextFieldDelegate.swift */,
 				3449771B234C295E00D71628 /* SHAutocorrectSuggestionView.m */,
+				3422113B2464BB390002E7C6 /* AutocorrectSuggestionViewDelegate.swift */,
+				3422112B24647AFF0002E7C6 /* EmailTextFieldDelegate.swift */,
 				342A1B1E2352BE4F00070FCD /* NSString+LevenshteinDistance.swift */,
+				342211392464BAA80002E7C6 /* SHAutocorrectSuggestionView.swift */,
+				342211372464AED90002E7C6 /* SHEmailValidationTextField.swift */,
 				342A1B192352AE1B00070FCD /* SHValidationResult.swift */,
 				349AD60123551C4D008BF413 /* SpotHeroEmailValidator.swift */,
 				342A1B162352A7EA00070FCD /* String+LevenshteinDistance.swift */,


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2066

**Description**
- Added boilerplate for `AutocorrectSuggestionViewDelegate` and `SHAutocorrectSuggestionView`. **They are removed from the SpotHeroEmailValidator build target so they don't conflict with existing values.**
- Fixed protocol for `AutocorrectSuggestionViewDelegate` on `SHEmailValidationTextField`.