### PR TITLE
Fixed bug with passedValidation property

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'bundler', '~> 2.1.4'
+gem 'bundler', '~> 2.2.2'
 gem 'cocoapods', '~> 1.10.0'
 gem 'danger', '~> 8.2.1'
 gem 'danger-swiftformat', '~> 0.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,15 +148,16 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
-  bundler (~> 2.1.4)
+  bundler (~> 2.2.2)
   cocoapods (~> 1.10.0)
-  danger (~> 8.2.0)
+  danger (~> 8.2.1)
   danger-swiftformat (~> 0.7.0)
-  danger-swiftlint (~> 0.24.4)
+  danger-swiftlint (~> 0.24.5)
   httparty (~> 0.18.1)
   plist (~> 3.5.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/Sources/SpotHeroEmailValidator/SHValidationResult.swift
+++ b/Sources/SpotHeroEmailValidator/SHValidationResult.swift
@@ -1,22 +1,12 @@
-//  Copyright © 2019 SpotHero, Inc. All rights reserved.
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-//
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
 public class SHValidationResult: NSObject {
+    /// Indicates whether or not the email address being analyzed is in valid syntax and format or not.
     @objc public let passedValidation: Bool
+    
+    /// The autocorrect suggestion to be applied. Nil if there no suggestion.
     @objc public let autocorrectSuggestion: String?
     
     @objc public init(passedValidation: Bool, autocorrectSuggestion: String?) {

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -182,7 +182,10 @@ private extension String {
     ///   - [What characters are allowed in an email address? (Stack Overflow](https://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-an-email-address)
     private static let emailRegexPattern = "\(Self.emailUsernameRegexPattern)@\(Self.emailDomainRegexPattern)"
     
+    // swiftlint:disable:next line_length
     private static let emailUsernameRegexPattern = #"(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")"#
+    
+    // swiftlint:disable:next line_length
     private static let emailDomainRegexPattern = #"(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])"#
     
     func isValidEmail() -> Bool {

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -1,17 +1,4 @@
-//  Copyright © 2019 SpotHero, Inc. All rights reserved.
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-//
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
@@ -26,7 +13,7 @@ public class SpotHeroEmailValidator: NSObject {
     private let commonDomains: [String]
     private let ianaRegisteredTLDs: [String]
     
-    private override init() {
+    override private init() {
         var dataDictionary: NSDictionary?
         
         // All TLDs registered with IANA as of October 8th, 2019 at 11:28 AM CST (latest list at: http://data.iana.org/TLD/tlds-alpha-by-domain.txt)
@@ -39,36 +26,39 @@ public class SpotHeroEmailValidator: NSObject {
         self.ianaRegisteredTLDs = dataDictionary?["IANARegisteredTLDs"] as? [String] ?? []
     }
     
-    // TODO: Remove @objc when entirely converted into Swift
-    @objc public func validateAndAutocorrect(emailAddress: String) throws -> SHValidationResult {
-        let autocorrectSuggestion = self.autocorrectSuggestion(for: emailAddress)
-        
-        return SHValidationResult(passedValidation: autocorrectSuggestion?.isEmpty == false,
-                                  autocorrectSuggestion: autocorrectSuggestion)
+    public func validateAndAutocorrect(emailAddress: String) throws -> SHValidationResult {
+        do {
+            // Attempt to get an autocorrect suggestion
+            // As long as no error is thrown, we can consider the email address to have passed validation
+            let autocorrectSuggestion = try self.autocorrectSuggestion(for: emailAddress)
+            
+            return SHValidationResult(passedValidation: true,
+                                      autocorrectSuggestion: autocorrectSuggestion)
+        } catch {
+            return SHValidationResult(passedValidation: false, autocorrectSuggestion: nil)
+        }
     }
     
-    // TODO: Remove @objc when entirely converted into Swift
-    @objc public func autocorrectSuggestion(for emailAddress: String) -> String? {
+    public func autocorrectSuggestion(for emailAddress: String) throws -> String? {
         guard let validated = try? self.validateSyntax(of: emailAddress), validated else {
-//            throw Error.invalidSyntax
-            return nil
+            throw Error.invalidSyntax
         }
 
         guard let emailParts = try? self.splitEmailAddress(emailAddress) else {
-            return nil
+            throw Error.invalidSyntax
         }
         
         var suggestedTLD = emailParts.tld
         
         if !self.ianaRegisteredTLDs.contains(emailParts.tld),
-            let closestTLD = self.closestString(for: emailParts.tld, fromArray: self.commonTLDs, withTolerance: 0.5) {
+           let closestTLD = self.closestString(for: emailParts.tld, fromArray: self.commonTLDs, withTolerance: 0.5) {
             suggestedTLD = closestTLD
         }
         
         var suggestedDomain = "\(emailParts.hostname).\(suggestedTLD)"
         
         if !self.commonDomains.contains(suggestedDomain),
-            let closestDomain = self.closestString(for: suggestedDomain, fromArray: self.commonDomains, withTolerance: 0.25) {
+           let closestDomain = self.closestString(for: suggestedDomain, fromArray: self.commonDomains, withTolerance: 0.25) {
             suggestedDomain = closestDomain
         }
         
@@ -112,14 +102,14 @@ public class SpotHeroEmailValidator: NSObject {
             return nil
         }
         
-        var closestString: String? = nil
+        var closestString: String?
         var closestDistance = Int.max
         
         // TODO: Use better name for arrayString parameter
         for arrayString in array {
             let distance = Int(string.levenshteinDistance(from: arrayString))
             
-            if distance < closestDistance && Float(distance) / Float(string.count) < tolerance {
+            if distance < closestDistance, Float(distance) / Float(string.count) < tolerance {
                 closestDistance = distance
                 closestString = arrayString
             }
@@ -158,8 +148,6 @@ public class SpotHeroEmailValidator: NSObject {
         
         return (username, domain, tld)
     }
-    
-    
 }
 
 // MARK: - Extensions

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -40,13 +40,12 @@ public class SpotHeroEmailValidator: NSObject {
     }
     
     public func autocorrectSuggestion(for emailAddress: String) throws -> String? {
-        guard let validated = try? self.validateSyntax(of: emailAddress), validated else {
-            throw Error.invalidSyntax
-        }
+        // Attempt to validate the syntax of the email address
+        // If the email address has incorrect format or syntax, an error will be thrown
+        try self.validateSyntax(of: emailAddress)
 
-        guard let emailParts = try? self.splitEmailAddress(emailAddress) else {
-            throw Error.invalidSyntax
-        }
+        // Split the email address into its component parts
+        let emailParts = try self.splitEmailAddress(emailAddress)
         
         var suggestedTLD = emailParts.tld
         
@@ -71,6 +70,7 @@ public class SpotHeroEmailValidator: NSObject {
         return suggestedEmailAddress
     }
     
+    @discardableResult
     public func validateSyntax(of emailAddress: String) throws -> Bool {
         // Split the email address into parts
         let emailParts = try self.splitEmailAddress(emailAddress)


### PR DESCRIPTION
**Description**
`passedValidation` should be true so long as the incoming/submitted email is in a valid syntax/format. If it isn't, it should actually throw an error. Previously, this was returning `false` if it had no autocorrect suggestion, which was incorrect logic.
