### PR TITLE
feature/manually trigger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
**Description**
Added the `workflow_dispatch` event which should allow manually triggering CI.

See: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
