### PR TITLE
IOS-3048: Bugfix/Trailing @ symbol passes validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   lint:
     name: Lint
     runs-on: macos-latest
+    permissions: 
+      pull requests: write
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     runs-on: macos-latest
     permissions: 
-      pull requests: write
+      pull-requests: write
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -118,12 +118,12 @@ public class SpotHeroEmailValidator: NSObject {
     }
 
     private func splitEmailAddress(_ emailAddress: String) throws -> EmailParts {
-        let emailAddressParts = emailAddress.split(separator: "@")
-        
-        guard emailAddressParts.count == 2 else {
-            // There are either no @ symbols or more than one @ symbol, throw an error
+        // Ensure there is exactly one @ symbol.
+        guard emailAddress.filter({ $0 == "@" }).count == 1 else {
             throw Error.invalidSyntax
         }
+        
+        let emailAddressParts = emailAddress.split(separator: "@")
         
         // Extract the username from the email address parts
         let username = String(emailAddressParts.first ?? "")

--- a/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
+++ b/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
@@ -20,6 +20,7 @@ class SpotHeroEmailValidatorTests: XCTestCase {
             ValidatorTestModel(emailAddress: "test.com", error: .invalidSyntax),
             ValidatorTestModel(emailAddress: #"test&*\"@email.com"#, error: .invalidSyntax),
             ValidatorTestModel(emailAddress: #"test&*\@email.com"#, error: .invalidSyntax),
+            ValidatorTestModel(emailAddress: "test@email.com@", error: .invalidSyntax),
             // Username Tests
             ValidatorTestModel(emailAddress: #"John..Doe@email.com"#, error: .invalidUsername),
             ValidatorTestModel(emailAddress: #".JohnDoe@email.com"#, error: .invalidUsername),


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3048

**Description**
Updates validation logic so an email with a trailing '@' does not pass validation (e.x. `email@domain.com@`)
