### PR TITLE
IOS-3370: Make email validation case insensitive 

### DIFF
--- a/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
+++ b/Sources/SpotHeroEmailValidator/AutocorrectSuggestionViewDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/SpotHeroEmailValidator/EmailTextFieldDelegate.swift
+++ b/Sources/SpotHeroEmailValidator/EmailTextFieldDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
+++ b/Sources/SpotHeroEmailValidator/SHAutocorrectSuggestionView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/SpotHeroEmailValidator/SHEmailValidationTextField.swift
+++ b/Sources/SpotHeroEmailValidator/SHEmailValidationTextField.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/SpotHeroEmailValidator/SHValidationResult.swift
+++ b/Sources/SpotHeroEmailValidator/SHValidationResult.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -75,7 +75,7 @@ public class SpotHeroEmailValidator: NSObject {
         let lowercasedEmailAddress = emailAddress.lowercased()
         
         // Split the email address into parts
-        let emailParts = try self.splitEmailAddress(lowerCasedEmailAddress)
+        let emailParts = try self.splitEmailAddress(lowercasedEmailAddress)
         
         // Ensure the username is valid by itself
         guard emailParts.username.isValidEmailUsername() else {
@@ -91,7 +91,7 @@ public class SpotHeroEmailValidator: NSObject {
         }
         
         // Ensure that the entire email forms a syntactically valid email
-        guard lowerCasedEmailAddress.isValidEmail() else {
+        guard lowercasedEmailAddress.isValidEmail() else {
             throw Error.invalidSyntax
         }
         

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -71,8 +71,11 @@ public class SpotHeroEmailValidator: NSObject {
     
     @discardableResult
     public func validateSyntax(of emailAddress: String) throws -> Bool {
+        // We are not validating against case sensitivity for emails
+        let lowerCasedEmailAddress = emailAddress.lowercased()
+        
         // Split the email address into parts
-        let emailParts = try self.splitEmailAddress(emailAddress)
+        let emailParts = try self.splitEmailAddress(lowerCasedEmailAddress)
         
         // Ensure the username is valid by itself
         guard emailParts.username.isValidEmailUsername() else {
@@ -88,7 +91,7 @@ public class SpotHeroEmailValidator: NSObject {
         }
         
         // Ensure that the entire email forms a syntactically valid email
-        guard emailAddress.isValidEmail() else {
+        guard lowerCasedEmailAddress.isValidEmail() else {
             throw Error.invalidSyntax
         }
         

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -72,7 +72,7 @@ public class SpotHeroEmailValidator: NSObject {
     @discardableResult
     public func validateSyntax(of emailAddress: String) throws -> Bool {
         // We are not validating against case sensitivity for emails
-        let lowerCasedEmailAddress = emailAddress.lowercased()
+        let lowercasedEmailAddress = emailAddress.lowercased()
         
         // Split the email address into parts
         let emailParts = try self.splitEmailAddress(lowerCasedEmailAddress)

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -71,11 +71,8 @@ public class SpotHeroEmailValidator: NSObject {
     
     @discardableResult
     public func validateSyntax(of emailAddress: String) throws -> Bool {
-        // We are not validating against case sensitivity for emails
-        let lowercasedEmailAddress = emailAddress.lowercased()
-        
         // Split the email address into parts
-        let emailParts = try self.splitEmailAddress(lowercasedEmailAddress)
+        let emailParts = try self.splitEmailAddress(emailAddress)
         
         // Ensure the username is valid by itself
         guard emailParts.username.isValidEmailUsername() else {
@@ -91,7 +88,7 @@ public class SpotHeroEmailValidator: NSObject {
         }
         
         // Ensure that the entire email forms a syntactically valid email
-        guard lowercasedEmailAddress.isValidEmail() else {
+        guard emailAddress.isValidEmail() else {
             throw Error.invalidSyntax
         }
         
@@ -191,17 +188,17 @@ private extension String {
     private static let emailDomainRegexPattern = #"(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])"#
     
     func isValidEmail() -> Bool {
-        return self.range(of: Self.emailRegexPattern, options: .regularExpression) != nil
+        return self.lowercased().range(of: Self.emailRegexPattern, options: .regularExpression) != nil
     }
     
     func isValidEmailUsername() -> Bool {
         return !self.hasPrefix(".")
             && !self.hasSuffix(".")
             && (self as NSString).range(of: "..").location == NSNotFound
-            && self.range(of: Self.emailUsernameRegexPattern, options: .regularExpression) != nil
+        && self.lowercased().range(of: Self.emailUsernameRegexPattern, options: .regularExpression) != nil
     }
     
     func isValidEmailDomain() -> Bool {
-        return self.range(of: Self.emailDomainRegexPattern, options: .regularExpression) != nil
+        return self.lowercased().range(of: Self.emailDomainRegexPattern, options: .regularExpression) != nil
     }
 }

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -195,7 +195,7 @@ private extension String {
         return !self.hasPrefix(".")
             && !self.hasSuffix(".")
             && (self as NSString).range(of: "..").location == NSNotFound
-        && self.lowercased().range(of: Self.emailUsernameRegexPattern, options: .regularExpression) != nil
+            && self.lowercased().range(of: Self.emailUsernameRegexPattern, options: .regularExpression) != nil
     }
     
     func isValidEmailDomain() -> Bool {

--- a/Sources/SpotHeroEmailValidator/String+LevenshteinDistance.swift
+++ b/Sources/SpotHeroEmailValidator/String+LevenshteinDistance.swift
@@ -8,8 +8,9 @@ public extension String {
     /// Source: [Minimum Edit Distance - Swift Algorithm Club](https://github.com/raywenderlich/swift-algorithm-club/tree/main/Minimum%20Edit%20Distance)
     /// - Parameter other: The other string to compare with.
     func levenshteinDistance(from other: String) -> Int {
-        let m = self.count // swiftlint:disable:this identifier_name
-        let n = other.count // swiftlint:disable:this identifier_name
+        // swiftlint:disable identifier_name
+        let m = self.count
+        let n = other.count
         var matrix = [[Int]](repeating: [Int](repeating: 0, count: n + 1), count: m + 1)
         
         // initialize matrix
@@ -36,6 +37,7 @@ public extension String {
                 }
             }
         }
+        // swiftlint:enable identifier_name
         return matrix[m][n]
     }
 }

--- a/Sources/SpotHeroEmailValidator/String+LevenshteinDistance.swift
+++ b/Sources/SpotHeroEmailValidator/String+LevenshteinDistance.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/AppDelegate.swift
+++ b/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import UIKit
 

--- a/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/SceneDelegate.swift
+++ b/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/SceneDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import UIKit
 

--- a/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/ViewController.swift
+++ b/SpotHeroEmailValidatorDemo/SpotHeroEmailValidatorDemo/ViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import SpotHeroEmailValidator
 import UIKit

--- a/Tests/SpotHeroEmailValidatorTests/LevenshteinDistanceTests.swift
+++ b/Tests/SpotHeroEmailValidatorTests/LevenshteinDistanceTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 @testable import SpotHeroEmailValidator
 import XCTest

--- a/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
+++ b/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
@@ -14,6 +14,7 @@ class SpotHeroEmailValidatorTests: XCTestCase {
         let tests = [
             // Successful Examples
             ValidatorTestModel(emailAddress: "test@email.com", error: nil),
+            ValidatorTestModel(emailAddress: "TEST@EMAIL.COM", error: nil),
             ValidatorTestModel(emailAddress: "test+-.test@email.com", error: nil),
             ValidatorTestModel(emailAddress: #""JohnDoe"@email.com"#, error: nil),
             // General Syntax Tests

--- a/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
+++ b/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 @testable import SpotHeroEmailValidator
 import XCTest


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3370

**Description**
- The example email in the ticket (`User@Domain.Photography`) was failing due to case sensitivity in the domain of the email address.  To fix this I made validation function entirely case insensitive.  
- Added a case sensitive test example to the validation unit test 