### PR TITLE
Fixed validation when username contains spaces

### DIFF
--- a/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
+++ b/Sources/SpotHeroEmailValidator/SpotHeroEmailValidator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2022 SpotHero, Inc. All rights reserved.
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
@@ -150,7 +150,7 @@ private extension String {
     
     // swiftlint:disable:next line_length
     private static let emailUsernameRegexPattern = #"(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")"#
-    
+
     // swiftlint:disable:next line_length
     private static let emailDomainRegexPattern = #"(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])"#
     
@@ -161,6 +161,7 @@ private extension String {
     func isValidEmailUsername() -> Bool {
         return !self.hasPrefix(".")
             && !self.hasSuffix(".")
+            && !self.contains(" ")
             && (self as NSString).range(of: "..").location == NSNotFound
             && self.lowercased().range(of: Self.emailUsernameRegexPattern, options: .regularExpression) != nil
     }

--- a/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
+++ b/Tests/SpotHeroEmailValidatorTests/SpotHeroEmailValidatorTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2022 SpotHero, Inc. All rights reserved.
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
 
 @testable import SpotHeroEmailValidator
 import XCTest
@@ -26,6 +26,7 @@ class SpotHeroEmailValidatorTests: XCTestCase {
             ValidatorTestModel(emailAddress: #"John..Doe@email.com"#, error: .invalidUsername),
             ValidatorTestModel(emailAddress: #".JohnDoe@email.com"#, error: .invalidUsername),
             ValidatorTestModel(emailAddress: #"JohnDoe.@email.com"#, error: .invalidUsername),
+            ValidatorTestModel(emailAddress: "te st@email.com", error: .invalidUsername),
             // Domain Tests
             ValidatorTestModel(emailAddress: "test@.com", error: .invalidDomain),
             ValidatorTestModel(emailAddress: "test@com", error: .invalidDomain),


### PR DESCRIPTION
**Issue Link**
AdHoc -- N/A

**Description**
The RFC doesn't allow for spaces in usernames and yet the validation was passing. Fixed it by making sure the username doesn't contain any spaces.